### PR TITLE
Closing tag parser should skip trailing whitespace

### DIFF
--- a/Text/XML/Light/Lexer.hs
+++ b/Text/XML/Light/Lexer.hs
@@ -139,7 +139,7 @@ qualName xs         = let (as,bs) = breakn endName xs
 
 tag              :: LString -> [Token]
 tag ((p,'/') : cs)    = let (n,ds) = qualName (dropSpace cs)
-                        in TokEnd p n : case ds of
+                        in TokEnd p n : case (dropSpace ds) of
                                           (_,'>') : es -> tokens' es
                                           -- tag was not properly closed...
                                           _        -> tokens' ds


### PR DESCRIPTION
According to http://www.w3.org/TR/xml/#sec-starttags , end tags are
allowed to have whitespace between the closing tag name and the '>'
character.  The grammar shows:

  ETag ::= '</' Name S? '>'

but the end-tag case does not handle the S? part (the opening tag
seems to handle it, though).

I have tested this diff with

<a>blah</a
><b>asdf</b>

As an example.  Without the change, extraneous CDATA elements
containing "\n>" are interspersed in the resulting document.  After
this change, the above contains no extraneous CDATA (but does still
have a node for the ending newline).