### PR TITLE
Fix typo in documentation

### DIFF
--- a/Text/XML/Light/Output.hs
+++ b/Text/XML/Light/Output.hs
@@ -36,7 +36,7 @@ data ConfigPP = ConfigPP
   , prettify      :: Bool
   }
 
--- | Default pretty orinting configuration.
+-- | Default pretty printing configuration.
 --  * Always use abbreviate empty tags.
 defaultConfigPP :: ConfigPP
 defaultConfigPP = ConfigPP { shortEmptyTag = const True


### PR DESCRIPTION
Just noticed a tiny typo when browsing documentation in Hackage.